### PR TITLE
Regestration sf

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.5.1p57
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,8 +3,11 @@ class Api::V1::UsersController < ApplicationController
   def create
     user1 = User.new(user_params)
     user1.update(api_key: SecureRandom.hex)
-    user1.save
-    render :json => UserSerializer.new(user1)
+    if !user1.save
+      render :json => UserSerializer.new(user1), status: :bad_request
+    else
+      render :json => UserSerializer.new(user1), status: :created
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,17 @@ class User < ApplicationRecord
   has_secure_password
   validates :email, uniqueness: true, presence: true
   validates :password, presence: true, if: :password
+  validates :password_confirmation, presence: true
 
+  def error_message
+    if password != password_confirmation
+      'Passwords gotta match!'
+    elsif User.find_by(email: email)
+      'Someone is already using your email?'
+    elsif email.empty? || password.empty?
+      'Sorry man. Need that email and password'
+    else
+      'Oops, it broke.'
+    end
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,5 @@
 class UserSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :email, :api_key
+  attributes :email, :api_key, if: Proc.new { |record| record.id }
+  attribute :error_message, if: Proc.new { |record| !record.id }
 end

--- a/spec/requests/api/v1/users/user_registration_spec.rb
+++ b/spec/requests/api/v1/users/user_registration_spec.rb
@@ -13,8 +13,56 @@ RSpec.describe 'Registration', :vcr do
     json = JSON.parse(response.body, symbolize_names: true)
 
     expect(json.class).to eq(Hash)
+    expect(response.status).to eq(201)
     expect(json[:data][:attributes]).to have_key :email
     expect(json[:data][:attributes]).to have_key :api_key
     expect(json[:data][:attributes][:email]).to eq('whatever@example.com')
+  end
+
+  it 'should error when not all fields are filled in' do
+    post '/api/v1/users', params: {
+        email: "",
+        password: "password",
+        password_confirmation: "password"
+    }
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.status).to eq(400)
+    expect(json[:data][:attributes][:error_message]).to eq("Sorry man. Need that email and password")
+  end
+
+  it 'should error when email is already registered' do
+    post '/api/v1/users', params: {
+        email: "whatever@example.com",
+        password: "password",
+        password_confirmation: "password"
+    }
+
+    expect(response.status).to eq(201)
+
+    post '/api/v1/users', params: {
+        email: "whatever@example.com",
+        password: "password",
+        password_confirmation: "password"
+    }
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.status).to eq(400)
+    expect(json[:data][:attributes][:error_message]).to eq("Someone is already using your email?")
+  end
+
+  it 'should error when passwords doesnt match' do
+    post '/api/v1/users', params: {
+        email: "whatever@example.com",
+        password: "password",
+        password_confirmation: "pass"
+    }
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response.status).to eq(400)
+    expect(json[:data][:attributes][:error_message]).to eq("Passwords gotta match!")
   end
 end


### PR DESCRIPTION
- Added a status call for create and error for user creation
- Added a conditional error call in the serializer 
- Gave errors specific messages in the user model
- Updated test with sad path testing
- Testing coverage at 90%